### PR TITLE
Make write batch size a config param

### DIFF
--- a/src/main/java/rockset/RocksetConnectorConfig.java
+++ b/src/main/java/rockset/RocksetConnectorConfig.java
@@ -24,6 +24,7 @@ public class RocksetConnectorConfig extends AbstractConfig {
   public static final String ROCKSET_COLLECTION = "rockset.collection";
   public static final String ROCKSET_WORKSPACE = "rockset.workspace";
   public static final String ROCKSET_TASK_THREADS = "rockset.task.threads";
+  public static final String ROCKSET_BATCH_SIZE = "rockset.batch.size";
 
   private RocksetConnectorConfig(ConfigDef config, Map<String, String> originals) {
     super(config, originals, true);
@@ -62,6 +63,14 @@ public class RocksetConnectorConfig extends AbstractConfig {
                 .importance(Importance.MEDIUM)
                 .defaultValue(5)
                 .build()
+        )
+
+        .define(
+                ConfigKeyBuilder.of(ROCKSET_BATCH_SIZE, Type.INT)
+                        .documentation("Number of documents batched before a write to Rockset")
+                        .importance(Importance.MEDIUM)
+                        .defaultValue(1000)
+                        .build()
         )
 
         .define(
@@ -156,6 +165,8 @@ public class RocksetConnectorConfig extends AbstractConfig {
   }
 
   public int getRocksetTaskThreads() { return this.getInt(ROCKSET_TASK_THREADS); }
+
+  public int getRocksetBatchSize() { return this.getInt(ROCKSET_BATCH_SIZE); }
 
   public String getFormat() {
     return this.getString(FORMAT);

--- a/src/main/java/rockset/RocksetSinkTask.java
+++ b/src/main/java/rockset/RocksetSinkTask.java
@@ -46,7 +46,6 @@ public class RocksetSinkTask extends SinkTask {
   private RocksetConnectorConfig config;
   private RecordParser recordParser;
 
-  private static final int BATCH_SIZE = 1000;
 
   private RecordParser getRecordParser(String format) {
     switch (format.toLowerCase()) {
@@ -159,7 +158,7 @@ public class RocksetSinkTask extends SinkTask {
 
   private void addDocs(String topic, Collection<SinkRecord> records) {
     log.debug("Adding {} records to Rockset for topic: {}", records.size(), topic);
-    this.rw.addDoc(topic, records, recordParser, BATCH_SIZE);
+    this.rw.addDoc(topic, records, recordParser, this.config.getRocksetBatchSize());
   }
 
   @Override

--- a/src/test/java/rockset/RocksetConnectorConfigTest.java
+++ b/src/test/java/rockset/RocksetConnectorConfigTest.java
@@ -41,9 +41,19 @@ public class RocksetConnectorConfigTest {
   }
 
   @Test
+  public void testBadBatchConfig() {
+    Map<String, String> badBatchConfig = new HashMap<>();
+    badBatchConfig.put("rockset.integration.key", "kafka://5");
+    badBatchConfig.put("rockset.batch.size", "xyz");
+
+    assertThrows(ConfigException.class, () -> new RocksetConnectorConfig(badBatchConfig));
+  }
+
+  @Test
   public void testGoodConfig() {
     Map<String, String> goodSettings = new HashMap<>();
     goodSettings.put("rockset.integration.key", "kafka://5");
+    goodSettings.put("rockset.batch.size", "10");
     goodSettings.put("format", "jSon");
 
     assertDoesNotThrow(() -> new RocksetConnectorConfig(goodSettings));


### PR DESCRIPTION
Allow for the add documents requests to be batched using a property instead of a static size of 1000.