### PR TITLE
rockset expects timestamps in microsecond resolution

### DIFF
--- a/src/main/java/rockset/LogicalConverters.java
+++ b/src/main/java/rockset/LogicalConverters.java
@@ -68,8 +68,9 @@ public class LogicalConverters {
 
     private Map<String, Object> convertToRocksetTimestamp(long timestampMillis) {
       Map<String, Object> timestampObj = new HashMap<>();
+      // rockset expects timestamps in microseconds
       timestampObj.put("__rockset_type", "timestamp");
-      timestampObj.put("value",  timestampMillis);
+      timestampObj.put("value",  timestampMillis * 1000);
       return timestampObj;
     }
   }

--- a/src/test/java/rockset/AvroParserTest.java
+++ b/src/test/java/rockset/AvroParserTest.java
@@ -206,17 +206,17 @@ public class AvroParserTest {
     String expectedOutput = "{\n" +
             "  \"data\" : [ {\n" +
             "    \"1\" : {\n" +
-            "      \"value\" : 1642784652,\n" +
+            "      \"value\" : 1642784652000,\n" +
             "      \"__rockset_type\" : \"timestamp\"\n" +
             "    }\n" +
             "  }, {\n" +
             "    \"2\" : {\n" +
-            "      \"value\" : 1642784653,\n" +
+            "      \"value\" : 1642784653000,\n" +
             "      \"__rockset_type\" : \"timestamp\"\n" +
             "    }\n" +
             "  }, {\n" +
             "    \"3\" : {\n" +
-            "      \"value\" : 1642784654,\n" +
+            "      \"value\" : 1642784654000,\n" +
             "      \"__rockset_type\" : \"timestamp\"\n" +
             "    }\n" +
             "  } ]\n" +
@@ -254,17 +254,17 @@ public class AvroParserTest {
             "  \"data\" : {\n" +
             "    \"foo\" : [ {\n" +
             "      \"1\" : {\n" +
-            "        \"value\" : 1642784652,\n" +
+            "        \"value\" : 1642784652000,\n" +
             "        \"__rockset_type\" : \"timestamp\"\n" +
             "      }\n" +
             "    }, {\n" +
             "      \"2\" : {\n" +
-            "        \"value\" : 1642784653,\n" +
+            "        \"value\" : 1642784653000,\n" +
             "        \"__rockset_type\" : \"timestamp\"\n" +
             "      }\n" +
             "    }, {\n" +
             "      \"3\" : {\n" +
-            "        \"value\" : 1642784654,\n" +
+            "        \"value\" : 1642784654000,\n" +
             "        \"__rockset_type\" : \"timestamp\"\n" +
             "      }\n" +
             "    } ]\n" +
@@ -636,8 +636,8 @@ public class AvroParserTest {
     assertEquals(expectedValue, parseValue(sr));
   }
 
-  private ImmutableMap<String, Object> rocksetTimestampType(Object time) {
-    return ImmutableMap.of("__rockset_type", "timestamp", "value", time);
+  private ImmutableMap<String, Object> rocksetTimestampType(long timeMs) {
+    return ImmutableMap.of("__rockset_type", "timestamp", "value", timeMs * 1000);
   }
 
   private ImmutableMap<String, Object> rocksetDateType(Object date) {


### PR DESCRIPTION
Convers Kafka timestamp types (in millisecond resolution) to Rockset's timestamp (in microsecond resolution).

This fixes a bug where a timestamp like 2022-06-29T09:32:05.234 will be treated as 1970-01-19T23:8:29 in Rockset.