### PR TITLE
Fix NPE when maps or arrays types are null

### DIFF
--- a/src/main/java/rockset/AvroParser.java
+++ b/src/main/java/rockset/AvroParser.java
@@ -19,6 +19,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import rockset.LogicalConverters.DateConverter;
 import rockset.LogicalConverters.LogicalTypeConverter;
@@ -121,6 +122,8 @@ class AvroParser implements RecordParser {
           return f.schema();
         }
       }
+
+      throw new DataException("found non-declared field: " + key);
     }
 
     return schema.valueSchema();

--- a/src/main/java/rockset/AvroParser.java
+++ b/src/main/java/rockset/AvroParser.java
@@ -57,13 +57,15 @@ class AvroParser implements RecordParser {
   }
 
   private Object convertType(Schema schema, Object o) {
+    if (o == null) {
+      return null;
+    }
+
     if (isLogicalType(schema)) {
       return convertLogicalType(schema, o);
     }
 
-    Type type = schema.type();
-
-    switch (type) {
+    switch (schema.type()) {
       case STRUCT:
       case MAP:
         return convertLogicalTypesMap(schema, (Map<String, Object>)o);
@@ -77,6 +79,10 @@ class AvroParser implements RecordParser {
   }
 
   public List<Object> convertLogicalTypesArray(Schema schema, List<Object> arr) {
+    if (arr == null) {
+      return null;
+    }
+
     List<Object> res = new ArrayList<>();
 
     for (Object o : arr) {
@@ -87,6 +93,10 @@ class AvroParser implements RecordParser {
   }
 
   public Map<String, Object> convertLogicalTypesMap(Schema valueSchema, Map<String, Object> map) {
+    if (map == null) {
+      return null;
+    }
+
     for (Entry<String, Object> e : map.entrySet()) {
       Schema schema = getSchemaForField(valueSchema, e.getKey());
       if (schema == null) {
@@ -117,6 +127,10 @@ class AvroParser implements RecordParser {
   }
 
   public Map<String, Object> getMap(Object val) {
+    if (val == null) {
+      return null;
+    }
+
     try {
       return new ObjectMapper().readValue(val.toString(), new TypeReference<Map<String, Object>>() {});
     } catch (IOException e) {

--- a/src/test/java/rockset/AvroParserTest.java
+++ b/src/test/java/rockset/AvroParserTest.java
@@ -722,12 +722,10 @@ public class AvroParserTest {
             "}";
 
     Map<String, Object> map = avroParser.getMap(value);
-    try {
-      avroParser.convertLogicalTypesMap(schema, map);
-      throw new RuntimeException("should have failed");
-    } catch (DataException e) {
-      assertEquals(e.getMessage(), "found non-declared field: nondefinedfield");
-    }
+    assertThrows(
+            DataException.class,
+            () -> avroParser.convertLogicalTypesMap(schema, map),
+            "found non-declared field: nondefinedfield");
   }
 
   private ImmutableMap<String, Object> rocksetTimestampType(long timeMs) {

--- a/src/test/java/rockset/AvroParserTest.java
+++ b/src/test/java/rockset/AvroParserTest.java
@@ -9,10 +9,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableSet;
 import io.confluent.connect.avro.AvroData;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -634,6 +636,62 @@ public class AvroParserTest {
 
     SinkRecord sr = makeSinkRecord(null, null, valueSchema, value);
     assertEquals(expectedValue, parseValue(sr));
+  }
+
+  @Test
+  public void testNullTypes() throws IOException {
+    final String schemaStr = "{\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"name\": \"KsqlDataSourceSchema\",\n" +
+            "  \"namespace\": \"io.confluent.ksql.avro_schemas\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"array_field\",\n" +
+            "      \"type\": [\n" +
+            "        \"null\",\n" +
+            "        {\n" +
+            "          \"type\": \"array\",\n" +
+            "          \"items\": [\n" +
+            "            \"null\",\n" +
+            "            \"string\"\n" +
+            "          ]\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"default\": null\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"map_field\",\n" +
+            "      \"type\": [\n" +
+            "        \"null\",\n" +
+            "        {\n" +
+            "          \"type\": \"map\",\n" +
+            "          \"values\": \"int\"\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"default\": null\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(schemaStr);
+    Schema schema = new AvroData(1).toConnectSchema(avroSchema);
+
+    AvroParser avroParser = new AvroParser();
+
+    String value = "{\n" +
+            "  \"array_field\": null,\n" +
+            "  \"map_field\": null\n" +
+            "}";
+
+    Map<String, Object> map = avroParser.getMap(value);
+    Map<String, Object> res = avroParser.convertLogicalTypesMap(schema, map);
+
+    assertEquals(res.keySet(), ImmutableSet.of("array_field", "map_field"));
+
+    List<Object> expectedValues = new ArrayList<Object>();
+    expectedValues.add(null);
+    expectedValues.add(null);
+    assertEquals(new ArrayList<Object>(res.values()), expectedValues);
   }
 
   private ImmutableMap<String, Object> rocksetTimestampType(long timeMs) {


### PR DESCRIPTION
Fix a NullPointerException when map or array fields are null.

Also, throw a better exception when a record contains unexpected fields.