### PR TITLE
In place cleanup of several abstractions

### DIFF
--- a/src/main/java/rockset/RequestWrapper.java
+++ b/src/main/java/rockset/RequestWrapper.java
@@ -2,6 +2,7 @@ package rockset;
 
 import java.util.Collection;
 import org.apache.kafka.connect.sink.SinkRecord;
+import rockset.parser.RecordParser;
 
 public interface RequestWrapper {
 

--- a/src/main/java/rockset/RocksetConnectorConfig.java
+++ b/src/main/java/rockset/RocksetConnectorConfig.java
@@ -139,20 +139,8 @@ public class RocksetConnectorConfig extends AbstractConfig {
     return this.getString(ROCKSET_APISERVER_URL);
   }
 
-  public String getRocksetApikey() {
-    return this.getString(ROCKSET_APIKEY);
-  }
-
   public String getRocksetIntegrationKey() {
     return this.getString(ROCKSET_INTEGRATION_KEY);
-  }
-
-  public String getRocksetCollection() {
-    return this.getString(ROCKSET_COLLECTION);
-  }
-
-  public String getRocksetWorkspace() {
-    return this.getString(ROCKSET_WORKSPACE);
   }
 
   public int getRocksetTaskThreads() {

--- a/src/main/java/rockset/parser/AvroParser.java
+++ b/src/main/java/rockset/parser/AvroParser.java
@@ -1,4 +1,4 @@
-package rockset;
+package rockset.parser;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,12 +20,12 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
-import rockset.LogicalConverters.DateConverter;
-import rockset.LogicalConverters.LogicalTypeConverter;
-import rockset.LogicalConverters.TimeConverter;
-import rockset.LogicalConverters.TimestampConverter;
+import rockset.parser.LogicalConverters.DateConverter;
+import rockset.parser.LogicalConverters.LogicalTypeConverter;
+import rockset.parser.LogicalConverters.TimeConverter;
+import rockset.parser.LogicalConverters.TimestampConverter;
 
-class AvroParser implements RecordParser {
+public class AvroParser implements RecordParser {
   private static final Map<String, LogicalTypeConverter> LOGICAL_TYPE_CONVERTERS =
       ImmutableMap.of(
           Time.SCHEMA.name(), new TimeConverter(),

--- a/src/main/java/rockset/parser/JsonParser.java
+++ b/src/main/java/rockset/parser/JsonParser.java
@@ -1,44 +1,18 @@
-package rockset;
+package rockset.parser;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.confluent.connect.avro.AvroData;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public interface RecordParser {
-
-  Map<String, Object> parseValue(SinkRecord record);
-
-  /**
-   * Parse key from a sink record. If key is struct type convert to Java Map type else return what
-   * is in the key
-   */
-  default Object parseKey(SinkRecord record) throws IOException {
-    if (record.key() instanceof Struct) {
-      AvroData keyData = new AvroData(1);
-      Object key = keyData.fromConnectData(record.keySchema(), record.key());
-      // For struct types convert to a Java Map object
-      return toMap(key);
-    }
-    return record.key();
-  }
-
-  static Object toMap(Object key) throws IOException {
-    return new ObjectMapper()
-        .readValue(key.toString(), new TypeReference<Map<String, Object>>() {});
-  }
-}
-
-class JsonParser implements RecordParser {
+public class JsonParser implements RecordParser {
   private static Logger log = LoggerFactory.getLogger(JsonParser.class);
   private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/rockset/parser/LogicalConverters.java
+++ b/src/main/java/rockset/parser/LogicalConverters.java
@@ -1,4 +1,4 @@
-package rockset;
+package rockset.parser;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/main/java/rockset/parser/RecordParser.java
+++ b/src/main/java/rockset/parser/RecordParser.java
@@ -1,0 +1,33 @@
+package rockset.parser;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.connect.avro.AvroData;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public interface RecordParser {
+
+  Map<String, Object> parseValue(SinkRecord record);
+
+  /**
+   * Parse key from a sink record. If key is struct type convert to Java Map type else return what
+   * is in the key
+   */
+  default Object parseKey(SinkRecord record) throws IOException {
+    if (record.key() instanceof Struct) {
+      AvroData keyData = new AvroData(1);
+      Object key = keyData.fromConnectData(record.keySchema(), record.key());
+      // For struct types convert to a Java Map object
+      return toMap(key);
+    }
+    return record.key();
+  }
+
+  static Object toMap(Object key) throws IOException {
+    return new ObjectMapper()
+        .readValue(key.toString(), new TypeReference<Map<String, Object>>() {});
+  }
+}

--- a/src/test/java/rockset/AvroParserTest.java
+++ b/src/test/java/rockset/AvroParserTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Test;
+import rockset.parser.AvroParser;
 
 public class AvroParserTest {
 

--- a/src/test/java/rockset/JsonParserTest.java
+++ b/src/test/java/rockset/JsonParserTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Test;
+import rockset.parser.JsonParser;
 
 public class JsonParserTest {
 

--- a/src/test/java/rockset/RocksetRequestWrapperTest.java
+++ b/src/test/java/rockset/RocksetRequestWrapperTest.java
@@ -20,6 +20,8 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import rockset.parser.AvroParser;
+import rockset.parser.JsonParser;
 
 public class RocksetRequestWrapperTest {
   private static RocksetConnectorConfig rcc;

--- a/src/test/java/rockset/RocksetSinkTaskTest.java
+++ b/src/test/java/rockset/RocksetSinkTaskTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -31,12 +32,14 @@ public class RocksetSinkTaskTest {
 
     RocksetSinkTask rst = new RocksetSinkTask();
     rst.start(settings, rr, executorService, retryExecutorService);
+    rst.open(Collections.singleton(new TopicPartition(topic, 1)));
 
     rst.put(records);
 
     Map<TopicPartition, OffsetAndMetadata> map = new HashMap();
     map.put(new TopicPartition(topic, 1), new OffsetAndMetadata(1L));
     rst.flush(map);
+    rst.close(Collections.singleton(new TopicPartition(topic, 1)));
 
     Mockito.verify(rr).addDoc(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt());
   }


### PR DESCRIPTION
Some unrelated cleanups. None of these should affect the logic of the connector.

Changes include:
* Simplify RocksetRequestWrapper error handling and unify its constructors
* Remove unneeded getters from RocksetConnectorConfig for deprecated fields
* Add explicit `open()` and `close()` overrides for RocksetSinkTask
* Move all parsers into a new package rockset.parser
* More consistent logging in several places